### PR TITLE
Use github release tag to set version in pypi

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 0.0.1
+commit = True
+tag = True
+
+[bumpversion:file:rl_cli/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 0.0.1
-commit = True
-tag = True
-
-[bumpversion:file:rl_cli/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -2,21 +2,34 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.1.1
+    
     - name: Set up Python
       uses: actions/setup-python@v5.0.0
       with:
         python-version: '3.12'
+    
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flit
+    
+    - name: Set version
+      run: |
+        # Extract version from GitHub release tag
+        VERSION=${GITHUB_REF#refs/tags/v}
+        # Update __init__.py with the new version
+        sed -i "s/__version__ = .*/__version__ = \"$VERSION\"/" rl_cli/__init__.py
+        # Display the new version for verification
+        echo "Updated version to $VERSION"
+        cat rl_cli/__init__.py
+    
     - name: Build and publish
       env:
         FLIT_USERNAME: __token__

--- a/rl_cli/__init__.py
+++ b/rl_cli/__init__.py
@@ -1,3 +1,4 @@
 """Runloop CLI for interacting with the Runloop APIs."""
 
-__version__ = "0.0.2"
+# DO NOT EDIT - this line will be updated automatically by bumpversion
+__version__ = "0.0.1"


### PR DESCRIPTION
## **Description**
- Changed the trigger for the PyPI publish workflow to activate on release publication instead of creation.
- Added a step in the PyPI publish workflow to dynamically set the package version in `rl_cli/__init__.py` by extracting it from the GitHub release tag.
- The `__version__` in `rl_cli/__init__.py` is now initialized to "0.0.1" and includes a comment indicating automatic version updates.
- Updated the Python setup step in the workflow to use Python version '3.12'.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Automatic Version Update in __init__.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rl_cli/__init__.py
<li>Version number in __init__.py is now set to "0.0.1" and marked to be <br>automatically updated.<br>


</details>
    

  </td>
  <td><a href="https://github.com/runloopai/rl-cli/pull/10/files#diff-d3417c0ec1a8bb3b80815377cd1ebeef41aeb293e81f09895cf08d765e34e171">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pypi_publish.yml</strong><dd><code>PyPI Publish Workflow Enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pypi_publish.yml
<li>Trigger for PyPI publish workflow changed from release created to <br>published.<br> <li> Python setup step now specifies Python version '3.12'.<br> <li> Added steps to set the version in __init__.py based on the GitHub <br>release tag.<br>


</details>
    

  </td>
  <td><a href="https://github.com/runloopai/rl-cli/pull/10/files#diff-e63c5d93f83e5bdcd906866da663fe90cbb5d5132b0b7b59c546b5c652e36fa9">+14/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
