### PR TITLE
refactor: simplify API key validation to single assertion check

### DIFF
--- a/rl_cli/main.py
+++ b/rl_cli/main.py
@@ -32,9 +32,6 @@ def ssh_url() -> str:
 
 @functools.cache
 def runloop_api_client() -> AsyncRunloop:
-    if not os.getenv("RUNLOOP_API_KEY"):
-        raise ValueError("RUNLOOP_API_KEY must be set in the environment.")
-
     return AsyncRunloop(bearer_token=os.getenv("RUNLOOP_API_KEY"), base_url=base_url())
 
 
@@ -384,8 +381,7 @@ async def devbox_tunnel(args) -> None:
         sys.exit(e.returncode)
 
 async def run():
-    if os.getenv("RUNLOOP_API_KEY") is None:
-        raise ValueError("Runloop API key not found in environment variables.")
+    assert os.getenv("RUNLOOP_API_KEY"), "API key not found, RUNLOOP_API_KEY must be set"
 
     parser = argparse.ArgumentParser(description="Perform various devbox operations.")
 

--- a/rl_cli/net.py
+++ b/rl_cli/net.py
@@ -6,9 +6,6 @@ import requests
 # Get the API key from the environment variable
 api_key = os.getenv("RUNLOOP_API_KEY")
 
-if api_key is None:
-    raise ValueError("API key not found in environment variables.")
-
 # Define the API endpoint
 base_url = "https://api.runloop.pro"
 


### PR DESCRIPTION
This PR simplifies our API key validation by:

- Consolidating all API key validation to a single assertion in run()
- Removing redundant checks from runloop_api_client() and net.py
- Improving error message clarity for users

This PR was authored by GitHub Copilot Chat/Claude.