### PR TITLE
print error when api key not set, allow help without

### DIFF
--- a/rl_cli/main.py
+++ b/rl_cli/main.py
@@ -436,10 +436,6 @@ async def devbox_tunnel(args) -> None:
 
 
 async def run():
-    assert os.getenv(
-        "RUNLOOP_API_KEY"
-    ), "API key not found, RUNLOOP_API_KEY must be set"
-
     parser = argparse.ArgumentParser(description="Perform various devbox operations.")
 
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -765,13 +761,19 @@ async def run():
 
     args = parser.parse_args()
     if hasattr(args, "func"):
+        if not os.getenv("RUNLOOP_API_KEY"):
+            raise RuntimeError("API key not found, RUNLOOP_API_KEY must be set")
         await args.func(args)
     else:
         parser.print_help()
 
 
 def main():
-    asyncio.run(run())
+    try:
+        asyncio.run(run())
+    except Exception as e:
+        print(f"error: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Testing:
```
(rl-cli) [~/source/rl-cli] # python -m rl_cli.main --help                                        
usage: main.py [-h] [--repo REPO] [--owner OWNER] {devbox,invocation,blueprint} ...

Perform various devbox operations.

positional arguments:
  {devbox,invocation,blueprint}
    devbox              Manage devboxes
    invocation          Manage invocations
    blueprint           Manage blueprints

options:
  -h, --help            show this help message and exit
  --repo REPO           Repo name.
  --owner OWNER         Repo owner.
(rl-cli) [~/source/rl-cli] # python -m rl_cli.main devbox create
error: API key not found, RUNLOOP_API_KEY must be set
```