### PR TITLE
Suppress stacktraces on ctrl-C

### DIFF
--- a/rl_cli/main.py
+++ b/rl_cli/main.py
@@ -1076,8 +1076,11 @@ async def run():
 def main():
     try:
         asyncio.run(run())
+    except KeyboardInterrupt:
+        print("Cancelled.", file=sys.stderr)
+        sys.exit(130)
     except Exception as e:
-        print(f"error: {e}")
+        print(f"error: {e}", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
Handle KeyboardInterrupt so that hitting ctrl-C on a long running command doesn't spam the terminal with stacktraces

Before:
```
➜  ~ rl devbox list --status=running  | grep db
Using dev environment
    "id": "dbx_2zwUjhUY7fNLLXVKXvtLB",
    "id": "dbx_2zwUjhUXxm67UyUeV07Qi",
    "id": "dbx_2zwUjhUSICVGQdKOVomJf",
    "id": "dbx_2zwUjhTy1XWe1MlblmQoD",
    "id": "dbx_2zwUjhTy132TMyo5DW5I0",
    "id": "dbx_2zwUjhN8zU7vQsYfB5P2n",
    "id": "dbx_2zwUjhN8keD5f22e6gkB6",
    "id": "dbx_2zwUjhN2qIFBdYjbdsxvg",
    "id": "dbx_2zwUjhN2n1TLXMRSl11s3",
    "id": "dbx_2zwUjhN2mgYbIdAPtEKGo",
    "id": "dbx_2zwUjhN2mRJVyRBec69Vh",
    "id": "dbx_2zwUjhN2kgU2bNqD5BEsS",
    "id": "dbx_2zwUjhN2kFXelpgrWZisp",
    "id": "dbx_2zwUjhN2cJ9BTxmEOCUOM",
    "id": "dbx_2zwUjhMwrzfx3NoxiQKRK",
^CTraceback (most recent call last):
  File "/Users/gautam/.local/share/uv/python/cpython-3.13.2-macos-aarch64-none/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/gautam/.local/share/uv/python/cpython-3.13.2-macos-aarch64-none/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
... (hundreds of lines)
```

After
```
Using dev environment
    "id": "dbx_2zwUjhUY7fNLLXVKXvtLB",
    "id": "dbx_2zwUjhUXxm67UyUeV07Qi",
    "id": "dbx_2zwUjhUSICVGQdKOVomJf",
    "id": "dbx_2zwUjhTy1XWe1MlblmQoD",
    "id": "dbx_2zwUjhTy132TMyo5DW5I0",
    "id": "dbx_2zwUjhN8zU7vQsYfB5P2n",
    "id": "dbx_2zwUjhN8keD5f22e6gkB6",
    "id": "dbx_2zwUjhN2qIFBdYjbdsxvg",
    "id": "dbx_2zwUjhN2n1TLXMRSl11s3",
    "id": "dbx_2zwUjhN2mgYbIdAPtEKGo",
    "id": "dbx_2zwUjhN2mRJVyRBec69Vh",
    "id": "dbx_2zwUjhN2kgU2bNqD5BEsS",
    "id": "dbx_2zwUjhN2kFXelpgrWZisp",
    "id": "dbx_2zwUjhN2cJ9BTxmEOCUOM",
    "id": "dbx_2zwUjhMwrzfx3NoxiQKRK",
^CCancelled.
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```