### PR TITLE
Migrate workflows to ubuntu-slim runner

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       contents: read
@@ -21,17 +21,11 @@ jobs:
       - name: Set up Python
         uses: runloopai/setup-python@main
         with:
-          python-version: "3.13"
-
-      - name: Cache pip
-        uses: runloopai/cache@main
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml', '**/uv.lock', '**/requirements.txt') }}
+          python-version: "3.12"
+          cache: pip
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -e .[dev]
 
       - name: Run linting checks

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -12,18 +12,18 @@ on:
         
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: runloopai/checkout@main
     
     - name: Set up Python
       uses: runloopai/setup-python@main
       with:
-        python-version: '3.12'
+        python-version: "3.12"
+        cache: pip
     
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install flit
     
     - name: Set version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -29,7 +29,6 @@ jobs:
         
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -e ".[dev]"
         
     - name: Run tests with coverage (exclude integration)


### PR DESCRIPTION
Also fix Python version discrepancy across workflows, use better workflow `pip` caching